### PR TITLE
Remove links `prev` 

### DIFF
--- a/API.md
+++ b/API.md
@@ -58,7 +58,6 @@ Returns json datas about all interviews.
             },
         ],
         "links": {
-            "prev": null,
             "next": "https://api.ironmental.net/interviews?tag={tag}&limit=4&offset=4"
         }
     }

--- a/src/transformer/interviewTransformer.js
+++ b/src/transformer/interviewTransformer.js
@@ -18,31 +18,14 @@ export const interviewTransform = interview => {
 
 export const interviewListTransform = (interviews, args) => {
   const { searchQuery, offsetNum, limitNum, tagName, total } = args;
-  let prevLink = `${API}/interviews?tag=${tagName}&search=${searchQuery}&offset=${offsetNum -
+  const nextLink = offsetNum + limitNum >= total ? null
+    : `${API}/interviews?tag=${tagName}&search=${searchQuery}&offset=${offsetNum +
     limitNum}&limit=${limitNum}`;
-  let nextLink = `${API}/interviews?tag=${tagName}&search=${searchQuery}&offset=${offsetNum +
-    limitNum}&limit=${limitNum}`;
-
-  switch (true) {
-    case offsetNum === 0:
-      prevLink = null;
-      break;
-    case offsetNum + limitNum >= total:
-      prevLink = `${API}/interviews?tag=${tagName}&search=${searchQuery}&offset=${total -
-      limitNum}&limit=${limitNum}`;
-      nextLink = null;
-      break;
-    case offsetNum - limitNum < 0:
-      prevLink = `${API}/interviews?tag=${tagName}&search=${searchQuery}&offset=0&limit=${limitNum}`;
-      break;
-    default:
-      break;
-  }
 
   return {
     datas: interviews.map(interviewTransform),
     links: {
-      prev: prevLink,
+      // prev: prevLink,
       next: nextLink,
     },
   };

--- a/src/transformer/interviewTransformer.test.js
+++ b/src/transformer/interviewTransformer.test.js
@@ -77,7 +77,6 @@ describe('[Transformer] interviewTransformer Test', () => {
         },
       ],
       links: {
-        prev: `${API}/interviews?tag=tag&search=search&offset=0&limit=4`,
         next: `${API}/interviews?tag=tag&search=search&offset=7&limit=4`,
       },
     };


### PR DESCRIPTION
클라이언트에서 interviews 글들을 요청하고 응답할 때 links 에 prev 역할이 필요없다고 생각되어 제거